### PR TITLE
fix(2fa): add missing await when generating two-factor secret

### DIFF
--- a/stubs/make/controller/two_factor_controller.stub
+++ b/stubs/make/controller/two_factor_controller.stub
@@ -12,7 +12,7 @@ export default class TwoFactorAuthController {
   async generate({ auth }: HttpContext) {
     const user = auth.user!
 
-    user.twoFactorSecret = twoFactorAuth.generateSecret(user.email)
+    user.twoFactorSecret = await twoFactorAuth.generateSecret(user.email)
     user.isTwoFactorEnabled = false
 
     await user.save()


### PR DESCRIPTION
The generate method in TwoFactorAuthController was assigning a Promise  to `user.twoFactorSecret` instead of the actual secret value. This caused  OTP verification failures. Added `await` to properly resolve the secret.

Fixes #5